### PR TITLE
Fixing the URL and the way to download and install Rambox

### DIFF
--- a/plugins/rambox.plugin/install.sh
+++ b/plugins/rambox.plugin/install.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-GITHUB_RELEASES_URL="https://api.github.com/repos/saenzramiro/rambox/releases"
-GITHUB_DOWNLOAD_URL="https://github.com/saenzramiro/rambox/releases/download"
+GITHUB_RELEASES_URL="https://api.github.com/repos/ramboxapp/community-edition/releases/latest"
 
 KERNEL=$(uname -m)
 
 case "$KERNEL" in
-  "x86_64") KERNEL_VERSION="x64" ;;
+  "x86_64") KERNEL_VERSION="x86_64" ;;
   *) KERNEL_VERSION="ia32" ;;
 esac
 
-URL=$(wget "$GITHUB_RELEASES_URL/latest" -O - | grep -o "$GITHUB_DOWNLOAD_URL/[0-9.]*/Rambox-[0-9.]*-$KERNEL_VERSION.rpm" | head -n 1)
+URL=$(curl -s $GITHUB_RELEASES_URL | grep -i browser_download_url | grep -i $KERNEL_VERSION.rpm | awk '{ print $2; }' | head -n 1)
 
 dnf -y install $URL
+

--- a/plugins/rambox.plugin/install.sh
+++ b/plugins/rambox.plugin/install.sh
@@ -9,7 +9,7 @@ case "$KERNEL" in
   *) KERNEL_VERSION="ia32" ;;
 esac
 
-URL=$(curl -s $GITHUB_RELEASES_URL | grep -i browser_download_url | grep -i $KERNEL_VERSION.rpm | awk '{ print $2; }' | head -n 1)
+URL=$(curl -s $GITHUB_RELEASES_URL | grep -i browser_download_url | grep -i $KERNEL_VERSION.rpm | awk '{ print $2; }' | head -n 1 | sed 's/\"//g')
 
 dnf -y install $URL
 


### PR DESCRIPTION
Hi, Dears

Since the URL for Github releases from Rambox was changed, the download and the installation of the package from Fedy was failing.
But not only the URL must be changed, the way to download the package also, since they rearranged the tree and the names of the binaries inside Github releases, so because of that, I changed a little bit the command that return the value for the URL variable.
I think in that way will prevent new failures to download and install the package (unless they don't intend to change the URL and the structure again :-) )

Thanks a lot in advance, if you agree with my PR
Kind regards

#StaySafe #StayAtHome