### PR TITLE
Fix errors when executing status.sh and install.sh scripts

### DIFF
--- a/plugins/codecs.plugin/install.sh
+++ b/plugins/codecs.plugin/install.sh
@@ -20,7 +20,7 @@ elif [ ${ID} != "fedora" -a "${VERSION_ID}" -lt 9 ]; then
   dnf -y install ffmpeg
 elif [ x$ffmpeg_free_test == x0 ] ; then
   dnf -y swap ffmpeg-free ffmpeg --allowerasing
-elif [ x$ffmpeg_free_test == x0 ] ; then
+elif [ x$libavcodec_free_test == x0 ] ; then
   dnf -y swap libavcodec-free ffmpeg-libs --allowerasing
 else
   dnf -y install ffmpeg

--- a/plugins/codecs.plugin/metadata.json
+++ b/plugins/codecs.plugin/metadata.json
@@ -7,12 +7,12 @@
 	"scripts": {
 		"exec": {
 			"label": "Install",
-			"command": "run-as-root install.sh"
+			"command": "run-as-root -s install.sh"
 		},
 		"undo": {
 			"label": "Remove",
-			"command": "run-as-root remove.sh"
+			"command": "run-as-root -s remove.sh"
 		},
-		"status": { "command": "status.sh" }
+		"status": { "command": "sh status.sh" }
 	}
 }

--- a/plugins/nvidia-gpu-driver-latest.plugin/metadata.json
+++ b/plugins/nvidia-gpu-driver-latest.plugin/metadata.json
@@ -13,6 +13,6 @@
 			"label": "Remove",
 			"command": "run-as-root -s remove.sh "
 		},
-		"status": { "command": "status.sh" }
+		"status": { "command": "sh status.sh" }
 	}
 }


### PR DESCRIPTION
Failed to check the status of the "Multimedia codecs" and "NVIDIA GPU driver (beta/latest)" plugins.

> 
> ...
> fedy: loading plugin Drivers::NVIDIA GPU driver (beta/latest)
> Failed to run process: Failed to execute child process “status.sh” (No such file or directory)
> ...
> fedy: loading plugin Utilities::Multimedia codecs
> Failed to run process: Failed to execute child process “status.sh” (No such file or directory)
> ...
> 

Failed to run `install.sh` script for multimedia codecs and crashed during `dnf -y groupinstall multimedia` on Fedora 39.

> $ fedy --add=codecs
> Failed to run process: Failed to execute child process “status.sh” (No such file or directory)
> Last metadata expiration check: 1:37:20 ago on Tue 13 Feb 2024 05:28:50 PM -03.
> Error: 
>  Problem: problem with installed package libswscale-free-6.0.1-2.fc39.x86_64
>   - package ffmpeg-libs-6.0-16.fc39.x86_64 from rpmfusion-free conflicts with libswscale-free provided by libswscale-free-6.0.1-2.fc39.x86_64 from @System
>   - package ffmpeg-libs-6.0-16.fc39.x86_64 from rpmfusion-free conflicts with libswscale-free provided by libswscale-free-6.0-11.fc39.x86_64 from fedora
>   - package ffmpeg-libs-6.0-16.fc39.x86_64 from rpmfusion-free conflicts with libswscale-free provided by libswscale-free-6.0.1-2.fc39.x86_64 from updates
>   - package ffmpeg-6.0-16.fc39.x86_64 from rpmfusion-free requires ffmpeg-libs(x86-64) = 6.0-16.fc39, but none of the providers can be installed
>   - conflicting requests
>   - package ffmpeg-6.0.1-3.fc39.x86_64 from rpmfusion-free-updates requires ffmpeg-libs(x86-64) = 6.0.1-3.fc39, but none of the providers can be installed
>   - package ffmpeg-libs-6.0.1-3.fc39.x86_64 from rpmfusion-free-updates conflicts with libswscale-free provided by libswscale-free-6.0.1-2.fc39.x86_64 from @System
>   - package ffmpeg-libs-6.0.1-3.fc39.x86_64 from rpmfusion-free-updates conflicts with libswscale-free provided by libswscale-free-6.0-11.fc39.x86_64 from fedora
>   - package ffmpeg-libs-6.0.1-3.fc39.x86_64 from rpmfusion-free-updates conflicts with libswscale-free provided by libswscale-free-6.0.1-2.fc39.x86_64 from updates
> (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
> Last metadata expiration check: 1:37:21 ago on Tue 13 Feb 2024 05:28:50 PM -03.
> No match for group package "PackageKit-gstreamer-plugin"
> No match for group package "gimp-heif-plugin"
> Error: 
>  Problem 1: problem with installed package libswscale-free-6.0.1-2.fc39.x86_64
>   - package ffmpeg-libs-6.0-16.fc39.x86_64 from rpmfusion-free conflicts with libswscale-free provided by libswscale-free-6.0.1-2.fc39.x86_64 from @System
>   - package ffmpeg-libs-6.0-16.fc39.x86_64 from rpmfusion-free conflicts with libswscale-free provided by libswscale-free-6.0-11.fc39.x86_64 from fedora
>   - package ffmpeg-libs-6.0-16.fc39.x86_64 from rpmfusion-free conflicts with libswscale-free provided by libswscale-free-6.0.1-2.fc39.x86_64 from updates
>   - package ffmpeg-6.0-16.fc39.x86_64 from rpmfusion-free requires ffmpeg-libs(x86-64) = 6.0-16.fc39, but none of the providers can be installed
>   - conflicting requests
>   - package ffmpeg-6.0.1-3.fc39.x86_64 from rpmfusion-free-updates requires ffmpeg-libs(x86-64) = 6.0.1-3.fc39, but none of the providers can be installed
>   - package ffmpeg-libs-6.0.1-3.fc39.x86_64 from rpmfusion-free-updates conflicts with libswscale-free provided by libswscale-free-6.0.1-2.fc39.x86_64 from @System
>   - package ffmpeg-libs-6.0.1-3.fc39.x86_64 from rpmfusion-free-updates conflicts with libswscale-free provided by libswscale-free-6.0-11.fc39.x86_64 from fedora
>   - package ffmpeg-libs-6.0.1-3.fc39.x86_64 from rpmfusion-free-updates conflicts with libswscale-free provided by libswscale-free-6.0.1-2.fc39.x86_64 from updates
>  Problem 2: problem with installed package firefox-122.0-5.fc39.x86_64
>   - conflicting requests
>   - package ffmpeg-libs-6.0-16.fc39.i686 from rpmfusion-free conflicts with libavcodec-free provided by libavcodec-free-6.0-11.fc39.x86_64 from fedora
>   - package ffmpeg-libs-6.0-16.fc39.x86_64 from rpmfusion-free conflicts with libavcodec-free provided by libavcodec-free-6.0-11.fc39.x86_64 from fedora
>   - package ffmpeg-libs-6.0.1-3.fc39.i686 from rpmfusion-free-updates conflicts with libavcodec-free provided by libavcodec-free-6.0-11.fc39.x86_64 from fedora
>   - package ffmpeg-libs-6.0.1-3.fc39.x86_64 from rpmfusion-free-updates conflicts with libavcodec-free provided by libavcodec-free-6.0-11.fc39.x86_64 from fedora
>   - problem with installed package libavcodec-free-6.0.1-2.fc39.x86_64
>   - package ffmpeg-libs-6.0-16.fc39.i686 from rpmfusion-free conflicts with libavcodec-free provided by libavcodec-free-6.0.1-2.fc39.x86_64 from updates
>   - package ffmpeg-libs-6.0-16.fc39.x86_64 from rpmfusion-free conflicts with libavcodec-free provided by libavcodec-free-6.0.1-2.fc39.x86_64 from updates
>   - package ffmpeg-libs-6.0.1-3.fc39.i686 from rpmfusion-free-updates conflicts with libavcodec-free provided by libavcodec-free-6.0.1-2.fc39.x86_64 from updates
>   - package ffmpeg-libs-6.0.1-3.fc39.x86_64 from rpmfusion-free-updates conflicts with libavcodec-free provided by libavcodec-free-6.0.1-2.fc39.x86_64 from updates
>   - package ffmpeg-libs-6.0-16.fc39.i686 from rpmfusion-free conflicts with libavcodec-free provided by libavcodec-free-6.0.1-2.fc39.x86_64 from @System
>   - package ffmpeg-libs-6.0-16.fc39.x86_64 from rpmfusion-free conflicts with libavcodec-free provided by libavcodec-free-6.0.1-2.fc39.x86_64 from @System
>   - package ffmpeg-libs-6.0.1-3.fc39.i686 from rpmfusion-free-updates conflicts with libavcodec-free provided by libavcodec-free-6.0.1-2.fc39.x86_64 from @System
>   - package ffmpeg-libs-6.0.1-3.fc39.x86_64 from rpmfusion-free-updates conflicts with libavcodec-free provided by libavcodec-free-6.0.1-2.fc39.x86_64 from @System
> (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages)
> 
> -------
> ✗ Add of 'Multimedia codecs' (Install) failed
