### PR TITLE
Revert "Add copr for spf-spotify-client"

### DIFF
--- a/plugins/spotify.plugin/install.sh
+++ b/plugins/spotify.plugin/install.sh
@@ -2,7 +2,4 @@
 
 dnf config-manager --set-disabled --repo=fedora-spotify -y &>/dev/null || :
 
-# See also https://github.com/rpmfusion/lpf-spotify-client/pull/17#issuecomment-1864322263
-dnf copr enable -y sergiomb/libayatana-appindicator
-
 dnf -y install lpf-spotify-client


### PR DESCRIPTION
This reverts commit 4d068b5fc9d0cebbc76b553c5fcae60f1d50b5a8.

libayatana-appindicator is now avaliable in Fedora , no need use copr repo anymore

