### PR TITLE
nvidia-cuda: Fix typo in status check

### DIFF
--- a/plugins/nvidia-cuda.plugin/metadata.json
+++ b/plugins/nvidia-cuda.plugin/metadata.json
@@ -13,6 +13,6 @@
 			"label": "Remove",
 			"command": "run-as-root -s remove.sh "
 		},
-		"status": { "command": "rpm --quiet --query cuda" }
+		"status": { "command": "rpm --quiet --query cuda-toolkit" }
 	}
 }


### PR DESCRIPTION
The name of the package seems to be cuda-toolkit, not cuda