### PR TITLE
plugins: fix dead repos and add dnf5 compatibility

### DIFF
--- a/plugins/arduino.plugin/install.sh
+++ b/plugins/arduino.plugin/install.sh
@@ -11,7 +11,7 @@ fi
 CACHEDIR="/var/cache/fedy/arduino";
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
-VERSION=$(wget "https://www.arduino.cc/en/Main/ReleaseNotes" -O - | grep -Po "ARDUINO [0-9.]{5}" | head -n 1 | cut -c 9-)
+VERSION=$(wget -qO- "https://api.github.com/repos/arduino/Arduino/releases/latest" | grep -Po '"tag_name": "\K[0-9.]+')
 FILE=arduino-$VERSION-linux$ARCH.tar.xz
 URL=https://downloads.arduino.cc/$FILE
 

--- a/plugins/bluejeans.plugin/install.sh
+++ b/plugins/bluejeans.plugin/install.sh
@@ -1,4 +1,6 @@
+# DEPRECATED: BlueJeans was discontinued. This plugin is non-functional.
 #!/bin/bash
 
-dnf -y install https://swdl.bluejeans.com/desktop-app/linux/2.0.0/BlueJeans.rpm
+echo "BlueJeans has been discontinued and is no longer available." >&2
+exit 1
 

--- a/plugins/brave.plugin/install.sh
+++ b/plugins/brave.plugin/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Instructions adopted from
-# https://brave-browser.readthedocs.io/en/latest/installing-brave.html#linux
+# https://brave.com/linux/
 
 cat > /etc/yum.repos.d/brave-browser.repo << "EOF"
 [brave-browser]

--- a/plugins/dockerce.plugin/install.sh
+++ b/plugins/dockerce.plugin/install.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo -y
+if dnf5 --version &>/dev/null; then
+  dnf config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
+else
+  dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo -y
+fi
+
 dnf install docker-ce -y
 
 usermod -aG docker ${USER}

--- a/plugins/dockerce.plugin/install.sh
+++ b/plugins/dockerce.plugin/install.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 if dnf5 --version &>/dev/null; then
-  dnf config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
+  dnf5 config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo
 else
-  dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo -y
+  dnf4 config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo -y
 fi
 
 dnf install docker-ce -y

--- a/plugins/eclipseautomotive.plugin/install.sh
+++ b/plugins/eclipseautomotive.plugin/install.sh
@@ -10,7 +10,7 @@ INSTALLDIR="/opt/eclipse-$PACKAGE"
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-BASEURL="http://mirror.cc.vt.edu/pub/eclipse/technology/epp/downloads/release"
+BASEURL="https://ftp.fau.de/eclipse/technology/epp/downloads/release"
 PRESENTRELEASE=$(wget $BASEURL/release.xml -O - | grep present | sed -n 's:.*<present>\(.*\)</present>.*:\1:p')
 PRODUCT=$(wget --quiet $BASEURL/$PRESENTRELEASE/$PACKAGE.xml -O - | grep "<product name=" | sed 's/.*"\(.*\)"[^"]*$/\1/')
 

--- a/plugins/eclipsecpp.plugin/install.sh
+++ b/plugins/eclipsecpp.plugin/install.sh
@@ -10,7 +10,7 @@ INSTALLDIR="/opt/eclipse-$PACKAGE"
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-BASEURL="http://mirror.cc.vt.edu/pub/eclipse/technology/epp/downloads/release"
+BASEURL="https://ftp.fau.de/eclipse/technology/epp/downloads/release"
 PRESENTRELEASE=$(wget $BASEURL/release.xml -O - | grep present | sed -n 's:.*<present>\(.*\)</present>.*:\1:p')
 PRODUCT=$(wget --quiet $BASEURL/$PRESENTRELEASE/$PACKAGE.xml -O - | grep "<product name=" | sed 's/.*"\(.*\)"[^"]*$/\1/')
 

--- a/plugins/eclipsedsl.plugin/install.sh
+++ b/plugins/eclipsedsl.plugin/install.sh
@@ -10,7 +10,7 @@ INSTALLDIR="/opt/eclipse-$PACKAGE"
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-BASEURL="http://mirror.cc.vt.edu/pub/eclipse/technology/epp/downloads/release"
+BASEURL="https://ftp.fau.de/eclipse/technology/epp/downloads/release"
 PRESENTRELEASE=$(wget $BASEURL/release.xml -O - | grep present | sed -n 's:.*<present>\(.*\)</present>.*:\1:p')
 PRODUCT=$(wget --quiet $BASEURL/$PRESENTRELEASE/$PACKAGE.xml -O - | grep "<product name=" | sed 's/.*"\(.*\)"[^"]*$/\1/')
 

--- a/plugins/eclipsejava.plugin/install.sh
+++ b/plugins/eclipsejava.plugin/install.sh
@@ -10,7 +10,7 @@ INSTALLDIR="/opt/eclipse-$PACKAGE"
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-BASEURL="http://mirror.cc.vt.edu/pub/eclipse/technology/epp/downloads/release"
+BASEURL="https://ftp.fau.de/eclipse/technology/epp/downloads/release"
 PRESENTRELEASE=$(wget $BASEURL/release.xml -O - | grep present | sed -n 's:.*<present>\(.*\)</present>.*:\1:p')
 PRODUCT=$(wget --quiet $BASEURL/$PRESENTRELEASE/$PACKAGE.xml -O - | grep "<product name=" | sed 's/.*"\(.*\)"[^"]*$/\1/')
 

--- a/plugins/eclipsejee.plugin/install.sh
+++ b/plugins/eclipsejee.plugin/install.sh
@@ -10,7 +10,7 @@ INSTALLDIR="/opt/eclipse-$PACKAGE"
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-BASEURL="http://mirror.cc.vt.edu/pub/eclipse/technology/epp/downloads/release"
+BASEURL="https://ftp.fau.de/eclipse/technology/epp/downloads/release"
 PRESENTRELEASE=$(wget $BASEURL/release.xml -O - | grep present | sed -n 's:.*<present>\(.*\)</present>.*:\1:p')
 PRODUCT=$(wget --quiet $BASEURL/$PRESENTRELEASE/$PACKAGE.xml -O - | grep "<product name=" | sed 's/.*"\(.*\)"[^"]*$/\1/')
 

--- a/plugins/eclipsemodeling.plugin/install.sh
+++ b/plugins/eclipsemodeling.plugin/install.sh
@@ -10,7 +10,7 @@ INSTALLDIR="/opt/eclipse-$PACKAGE"
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-BASEURL="http://mirror.cc.vt.edu/pub/eclipse/technology/epp/downloads/release"
+BASEURL="https://ftp.fau.de/eclipse/technology/epp/downloads/release"
 PRESENTRELEASE=$(wget $BASEURL/release.xml -O - | grep present | sed -n 's:.*<present>\(.*\)</present>.*:\1:p')
 PRODUCT=$(wget --quiet $BASEURL/$PRESENTRELEASE/$PACKAGE.xml -O - | grep "<product name=" | sed 's/.*"\(.*\)"[^"]*$/\1/')
 

--- a/plugins/eclipseparallel.plugin/install.sh
+++ b/plugins/eclipseparallel.plugin/install.sh
@@ -10,7 +10,7 @@ INSTALLDIR="/opt/eclipse-$PACKAGE"
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-BASEURL="http://mirror.cc.vt.edu/pub/eclipse/technology/epp/downloads/release"
+BASEURL="https://ftp.fau.de/eclipse/technology/epp/downloads/release"
 PRESENTRELEASE=$(wget $BASEURL/release.xml -O - | grep present | sed -n 's:.*<present>\(.*\)</present>.*:\1:p')
 PRODUCT=$(wget --quiet $BASEURL/$PRESENTRELEASE/$PACKAGE.xml -O - | grep "<product name=" | sed 's/.*"\(.*\)"[^"]*$/\1/')
 

--- a/plugins/eclipsephp.plugin/install.sh
+++ b/plugins/eclipsephp.plugin/install.sh
@@ -10,7 +10,7 @@ INSTALLDIR="/opt/eclipse-$PACKAGE"
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-BASEURL="http://mirror.cc.vt.edu/pub/eclipse/technology/epp/downloads/release"
+BASEURL="https://ftp.fau.de/eclipse/technology/epp/downloads/release"
 PRESENTRELEASE=$(wget $BASEURL/release.xml -O - | grep present | sed -n 's:.*<present>\(.*\)</present>.*:\1:p')
 PRODUCT=$(wget --quiet $BASEURL/$PRESENTRELEASE/$PACKAGE.xml -O - | grep "<product name=" | sed 's/.*"\(.*\)"[^"]*$/\1/')
 

--- a/plugins/eclipsercp.plugin/install.sh
+++ b/plugins/eclipsercp.plugin/install.sh
@@ -10,7 +10,7 @@ INSTALLDIR="/opt/eclipse-$PACKAGE"
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-BASEURL="http://mirror.cc.vt.edu/pub/eclipse/technology/epp/downloads/release"
+BASEURL="https://ftp.fau.de/eclipse/technology/epp/downloads/release"
 PRESENTRELEASE=$(wget $BASEURL/release.xml -O - | grep present | sed -n 's:.*<present>\(.*\)</present>.*:\1:p')
 PRODUCT=$(wget --quiet $BASEURL/$PRESENTRELEASE/$PACKAGE.xml -O - | grep "<product name=" | sed 's/.*"\(.*\)"[^"]*$/\1/')
 

--- a/plugins/eclipsereporting.plugin/install.sh
+++ b/plugins/eclipsereporting.plugin/install.sh
@@ -10,7 +10,7 @@ INSTALLDIR="/opt/eclipse-$PACKAGE"
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-BASEURL="http://mirror.cc.vt.edu/pub/eclipse/technology/epp/downloads/release"
+BASEURL="https://ftp.fau.de/eclipse/technology/epp/downloads/release"
 PRESENTRELEASE=$(wget $BASEURL/release.xml -O - | grep present | sed -n 's:.*<present>\(.*\)</present>.*:\1:p')
 PRODUCT=$(wget --quiet $BASEURL/$PRESENTRELEASE/$PACKAGE.xml -O - | grep "<product name=" | sed 's/.*"\(.*\)"[^"]*$/\1/')
 

--- a/plugins/eclipsescout.plugin/install.sh
+++ b/plugins/eclipsescout.plugin/install.sh
@@ -10,7 +10,7 @@ INSTALLDIR="/opt/eclipse-$PACKAGE"
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-BASEURL="http://mirror.cc.vt.edu/pub/eclipse/technology/epp/downloads/release"
+BASEURL="https://ftp.fau.de/eclipse/technology/epp/downloads/release"
 PRESENTRELEASE=$(wget $BASEURL/release.xml -O - | grep present | sed -n 's:.*<present>\(.*\)</present>.*:\1:p')
 PRODUCT=$(wget --quiet $BASEURL/$PRESENTRELEASE/$PACKAGE.xml -O - | grep "<product name=" | sed 's/.*"\(.*\)"[^"]*$/\1/')
 

--- a/plugins/eclipsestandard.plugin/install.sh
+++ b/plugins/eclipsestandard.plugin/install.sh
@@ -10,7 +10,7 @@ INSTALLDIR="/opt/eclipse-$PACKAGE"
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-BASEURL="http://mirror.cc.vt.edu/pub/eclipse/technology/epp/downloads/release"
+BASEURL="https://ftp.fau.de/eclipse/technology/epp/downloads/release"
 PRESENTRELEASE=$(wget $BASEURL/release.xml -O - | grep present | sed -n 's:.*<present>\(.*\)</present>.*:\1:p')
 PRODUCT=$(wget --quiet $BASEURL/$PRESENTRELEASE/$PACKAGE.xml -O - | grep "<product name=" | sed 's/.*"\(.*\)"[^"]*$/\1/')
 

--- a/plugins/eclipsetesting.plugin/install.sh
+++ b/plugins/eclipsetesting.plugin/install.sh
@@ -10,7 +10,7 @@ INSTALLDIR="/opt/eclipse-$PACKAGE"
 mkdir -p "$CACHEDIR"
 cd "$CACHEDIR"
 
-BASEURL="http://mirror.cc.vt.edu/pub/eclipse/technology/epp/downloads/release"
+BASEURL="https://ftp.fau.de/eclipse/technology/epp/downloads/release"
 PRESENTRELEASE=$(wget $BASEURL/release.xml -O - | grep present | sed -n 's:.*<present>\(.*\)</present>.*:\1:p')
 PRODUCT=$(wget --quiet $BASEURL/$PRESENTRELEASE/$PACKAGE.xml -O - | grep "<product name=" | sed 's/.*"\(.*\)"[^"]*$/\1/')
 

--- a/plugins/forticlient.plugin/install.sh
+++ b/plugins/forticlient.plugin/install.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-cat > /etc/yum.repos.d/fortinet.repo << "EOF" 
+cat > /etc/yum.repos.d/fortinet.repo << "EOF"
 [repo.fortinet.com]
-name=Fortinet CentOS 7 repository
-baseurl=https://repo.fortinet.com/repo/7.0/centos/8/os/x86_64/
+name=Fortinet CentOS 8 repository
+baseurl=https://repo.fortinet.com/repo/forticlient/7.4/centos/8/os/x86_64/
 enabled=1
-gpgkey=https://repo.fortinet.com/repo/7.0/centos/8/os/x86_64/RPM-GPG-KEY
+gpgkey=https://repo.fortinet.com/repo/forticlient/7.4/centos/8/os/x86_64/RPM-GPG-KEY
 gpgcheck=1
 EOF
 

--- a/plugins/githubcli.plugin/install.sh
+++ b/plugins/githubcli.plugin/install.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 if dnf5 --version &>/dev/null; then
-  dnf config-manager addrepo --from-repofile=https://cli.github.com/packages/rpm/gh-cli.repo
+  dnf5 config-manager addrepo --from-repofile=https://cli.github.com/packages/rpm/gh-cli.repo
 else
-  dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+  dnf4 config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
 fi
 
 dnf -y install gh

--- a/plugins/githubcli.plugin/install.sh
+++ b/plugins/githubcli.plugin/install.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+if dnf5 --version &>/dev/null; then
+  dnf config-manager addrepo --from-repofile=https://cli.github.com/packages/rpm/gh-cli.repo
+else
+  dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+fi
 
 dnf -y install gh

--- a/plugins/githubdesktop.plugin/install.sh
+++ b/plugins/githubdesktop.plugin/install.sh
@@ -3,14 +3,16 @@
 # Instructions adopted from
 # https://github.com/shiftkey/desktop
 
-cat > /etc/yum.repos.d/GithubDesktop-Fedora.repo << "EOF" 
-[shiftkey]
+rpm --import https://mirror.mwt.me/shiftkey-desktop/gpgkey
+
+cat > /etc/yum.repos.d/shiftkey-packages.repo << "EOF"
+[mwt-packages]
 name=GitHub Desktop
-baseurl=https://rpm.packages.shiftkey.dev/rpm/
+baseurl=https://mirror.mwt.me/shiftkey-desktop/rpm
 enabled=1
 gpgcheck=1
 repo_gpgcheck=1
-gpgkey=https://rpm.packages.shiftkey.dev/gpg.key
+gpgkey=https://mirror.mwt.me/shiftkey-desktop/gpgkey
 EOF
 
 dnf install github-desktop -y

--- a/plugins/githubdesktop.plugin/uninstall.sh
+++ b/plugins/githubdesktop.plugin/uninstall.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [ -f "/etc/yum.repos.d/shiftkey-packages.repo" ]; then
+  rm -f /etc/yum.repos.d/shiftkey-packages.repo
+fi
+
+# Clean up legacy repo file name
 if [ -f "/etc/yum.repos.d/GithubDesktop-Fedora.repo" ]; then
   rm -f /etc/yum.repos.d/GithubDesktop-Fedora.repo
 fi

--- a/plugins/google-cloud-sdk.plugin/install.sh
+++ b/plugins/google-cloud-sdk.plugin/install.sh
@@ -3,14 +3,13 @@
 # https://cloud.google.com/sdk/docs/quickstart-redhat-centos
 
 cat > /etc/yum.repos.d/google-cloud-sdk.repo << EOM
-[google-cloud-sdk]
-name=Google Cloud SDK
-baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
+[google-cloud-cli]
+name=Google Cloud CLI
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-\$basearch
 enabled=1
 gpgcheck=1
-repo_gpgcheck=1
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
-       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+repo_gpgcheck=0
+gpgkey=https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
 EOM
 
 # Install the Cloud SDK

--- a/plugins/microsoft-edge-stable.plugin/install.sh
+++ b/plugins/microsoft-edge-stable.plugin/install.sh
@@ -1,26 +1,11 @@
 #!/bin/bash
 
- . /etc/os-release
-
 rpm --import https://packages.microsoft.com/keys/microsoft.asc
 
-
-dnf4_repo_install() {
-  dnf config-manager --add-repo https://packages.microsoft.com/yumrepos/edge
-}
-
-dnf5_repo_install() {
+if dnf5 --version &>/dev/null; then
   dnf config-manager addrepo --from-repofile=https://packages.microsoft.com/yumrepos/edge/config.repo --save-filename=microsoft-edge-stable --overwrite
-}
+else
+  dnf config-manager --add-repo https://packages.microsoft.com/yumrepos/edge
+fi
 
-dnf_repo_install(){
-  case ${VERSION_ID} in
-    40) dnf4_repo_install ;;
-    4*) dnf5_repo_install;;
-    5*) dnf5_repo_install;;
-    *) dnf4_repo_install ;;
-  esac
-}
-
-dnf_repo_install
 dnf install microsoft-edge-stable -y

--- a/plugins/microsoft-edge-stable.plugin/install.sh
+++ b/plugins/microsoft-edge-stable.plugin/install.sh
@@ -3,9 +3,9 @@
 rpm --import https://packages.microsoft.com/keys/microsoft.asc
 
 if dnf5 --version &>/dev/null; then
-  dnf config-manager addrepo --from-repofile=https://packages.microsoft.com/yumrepos/edge/config.repo --save-filename=microsoft-edge-stable --overwrite
+  dnf5 config-manager addrepo --from-repofile=https://packages.microsoft.com/yumrepos/edge/config.repo --save-filename=microsoft-edge-stable --overwrite
 else
-  dnf config-manager --add-repo https://packages.microsoft.com/yumrepos/edge
+  dnf4 config-manager --add-repo https://packages.microsoft.com/yumrepos/edge
 fi
 
 dnf install microsoft-edge-stable -y

--- a/plugins/mullvadvpn.plugin/install.sh
+++ b/plugins/mullvadvpn.plugin/install.sh
@@ -1,14 +1,11 @@
 #!/bin/bash
 
-cat > /etc/yum.repos.d/mullvad-vpn.repo << "EOF"
-[mullvad-stable]
-name=Mullvad VPN
-baseurl=https://repository.mullvad.net/rpm/stable/$basearch
-type=rpm
-enabled=1
-gpgcheck=1
-gpgkey=https://repository.mullvad.net/rpm/mullvad-keyring.asc
-EOF
+# https://mullvad.net/en/download/vpn/linux
+if dnf5 --version &>/dev/null; then
+  dnf config-manager addrepo --from-repofile=https://repository.mullvad.net/rpm/stable/mullvad.repo
+else
+  dnf config-manager --add-repo https://repository.mullvad.net/rpm/stable/mullvad.repo
+fi
 
 dnf install mullvad-vpn -y
 

--- a/plugins/mullvadvpn.plugin/install.sh
+++ b/plugins/mullvadvpn.plugin/install.sh
@@ -2,9 +2,9 @@
 
 # https://mullvad.net/en/download/vpn/linux
 if dnf5 --version &>/dev/null; then
-  dnf config-manager addrepo --from-repofile=https://repository.mullvad.net/rpm/stable/mullvad.repo
+  dnf5 config-manager addrepo --from-repofile=https://repository.mullvad.net/rpm/stable/mullvad.repo
 else
-  dnf config-manager --add-repo https://repository.mullvad.net/rpm/stable/mullvad.repo
+  dnf4 config-manager --add-repo https://repository.mullvad.net/rpm/stable/mullvad.repo
 fi
 
 dnf install mullvad-vpn -y

--- a/plugins/nvidia-cuda.plugin/install.sh
+++ b/plugins/nvidia-cuda.plugin/install.sh
@@ -167,9 +167,9 @@ el8_cuda_install() {
 
 el9_cuda_install() {
   if dnf5 --version &>/dev/null; then
-    dnf config-manager addrepo --from-repofile=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${cuda_arch}/cuda-rhel9.repo
+    dnf5 config-manager addrepo --from-repofile=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${cuda_arch}/cuda-rhel9.repo
   else
-    dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${cuda_arch}/cuda-rhel9.repo
+    dnf4 config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${cuda_arch}/cuda-rhel9.repo
   fi
   dnf -y module disable nvidia-driver
   dnf install -y xorg-x11-drv-nvidia-cuda
@@ -178,9 +178,9 @@ el9_cuda_install() {
 
 el10_cuda_install() {
   if dnf5 --version &>/dev/null; then
-    dnf config-manager addrepo --from-repofile=https://developer.download.nvidia.com/compute/cuda/repos/rhel10/${cuda_arch}/cuda-rhel10.repo
+    dnf5 config-manager addrepo --from-repofile=https://developer.download.nvidia.com/compute/cuda/repos/rhel10/${cuda_arch}/cuda-rhel10.repo
   else
-    dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel10/${cuda_arch}/cuda-rhel10.repo
+    dnf4 config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel10/${cuda_arch}/cuda-rhel10.repo
   fi
   dnf install -y xorg-x11-drv-nvidia-cuda
   dnf mark user xorg-x11-drv-nvidia-cuda

--- a/plugins/nvidia-cuda.plugin/install.sh
+++ b/plugins/nvidia-cuda.plugin/install.sh
@@ -166,22 +166,14 @@ el8_cuda_install() {
 }
 
 el9_cuda_install() {
-  if dnf5 --version &>/dev/null; then
-    dnf5 config-manager addrepo --from-repofile=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${cuda_arch}/cuda-rhel9.repo
-  else
-    dnf4 config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${cuda_arch}/cuda-rhel9.repo
-  fi
+  dnf4 config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${cuda_arch}/cuda-rhel9.repo
   dnf -y module disable nvidia-driver
   dnf install -y xorg-x11-drv-nvidia-cuda
   dnf mark user xorg-x11-drv-nvidia-cuda
 }
 
 el10_cuda_install() {
-  if dnf5 --version &>/dev/null; then
-    dnf5 config-manager addrepo --from-repofile=https://developer.download.nvidia.com/compute/cuda/repos/rhel10/${cuda_arch}/cuda-rhel10.repo
-  else
-    dnf4 config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel10/${cuda_arch}/cuda-rhel10.repo
-  fi
+  dnf4 config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel10/${cuda_arch}/cuda-rhel10.repo
   dnf install -y xorg-x11-drv-nvidia-cuda
   dnf mark user xorg-x11-drv-nvidia-cuda
 }

--- a/plugins/nvidia-cuda.plugin/install.sh
+++ b/plugins/nvidia-cuda.plugin/install.sh
@@ -166,14 +166,22 @@ el8_cuda_install() {
 }
 
 el9_cuda_install() {
-  dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${cuda_arch}/cuda-rhel9.repo
+  if dnf5 --version &>/dev/null; then
+    dnf config-manager addrepo --from-repofile=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${cuda_arch}/cuda-rhel9.repo
+  else
+    dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel9/${cuda_arch}/cuda-rhel9.repo
+  fi
   dnf -y module disable nvidia-driver
   dnf install -y xorg-x11-drv-nvidia-cuda
   dnf mark user xorg-x11-drv-nvidia-cuda
 }
 
 el10_cuda_install() {
-  dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel10/${cuda_arch}/cuda-rhel10.repo
+  if dnf5 --version &>/dev/null; then
+    dnf config-manager addrepo --from-repofile=https://developer.download.nvidia.com/compute/cuda/repos/rhel10/${cuda_arch}/cuda-rhel10.repo
+  else
+    dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel10/${cuda_arch}/cuda-rhel10.repo
+  fi
   dnf install -y xorg-x11-drv-nvidia-cuda
   dnf mark user xorg-x11-drv-nvidia-cuda
 }

--- a/plugins/onedrive.plugin/install.sh
+++ b/plugins/onedrive.plugin/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-# https://github.com/abraunegg/onedrive/blob/master/docs/INSTALL.md
+# https://github.com/abraunegg/onedrive/blob/master/docs/install.md
 
 dnf install onedrive -y

--- a/plugins/proton-vpn.plugin/install.sh
+++ b/plugins/proton-vpn.plugin/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Instructions adopted from
-# http://rpm.anydesk.com/howto.html
+# https://protonvpn.com/support/official-linux-vpn-fedora
 
 cat > /etc/yum.repos.d/protonvpn.repo << "EOF" 
 #

--- a/plugins/spotify.plugin/install.sh
+++ b/plugins/spotify.plugin/install.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 if dnf5 --version &>/dev/null; then
-  dnf config-manager setopt fedora-spotify.enabled=0 &>/dev/null || :
+  dnf5 config-manager setopt fedora-spotify.enabled=0 &>/dev/null || :
 else
-  dnf config-manager --set-disabled --repo=fedora-spotify -y &>/dev/null || :
+  dnf4 config-manager --set-disabled --repo=fedora-spotify -y &>/dev/null || :
 fi
 
 dnf -y install lpf-spotify-client

--- a/plugins/spotify.plugin/install.sh
+++ b/plugins/spotify.plugin/install.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-dnf config-manager --set-disabled --repo=fedora-spotify -y &>/dev/null || :
+if dnf5 --version &>/dev/null; then
+  dnf config-manager setopt fedora-spotify.enabled=0 &>/dev/null || :
+else
+  dnf config-manager --set-disabled --repo=fedora-spotify -y &>/dev/null || :
+fi
 
 dnf -y install lpf-spotify-client

--- a/plugins/sublimetext.plugin/install.sh
+++ b/plugins/sublimetext.plugin/install.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
 rpm -v --import https://download.sublimetext.com/sublimehq-rpm-pub.gpg
-dnf config-manager --add-repo https://download.sublimetext.com/rpm/stable/x86_64/sublime-text.repo
+
+if dnf5 --version &>/dev/null; then
+  dnf config-manager addrepo --from-repofile=https://download.sublimetext.com/rpm/stable/x86_64/sublime-text.repo
+else
+  dnf config-manager --add-repo https://download.sublimetext.com/rpm/stable/x86_64/sublime-text.repo
+fi
+
 dnf -y install sublime-text

--- a/plugins/sublimetext.plugin/install.sh
+++ b/plugins/sublimetext.plugin/install.sh
@@ -3,9 +3,9 @@
 rpm -v --import https://download.sublimetext.com/sublimehq-rpm-pub.gpg
 
 if dnf5 --version &>/dev/null; then
-  dnf config-manager addrepo --from-repofile=https://download.sublimetext.com/rpm/stable/x86_64/sublime-text.repo
+  dnf5 config-manager addrepo --from-repofile=https://download.sublimetext.com/rpm/stable/x86_64/sublime-text.repo
 else
-  dnf config-manager --add-repo https://download.sublimetext.com/rpm/stable/x86_64/sublime-text.repo
+  dnf4 config-manager --add-repo https://download.sublimetext.com/rpm/stable/x86_64/sublime-text.repo
 fi
 
 dnf -y install sublime-text


### PR DESCRIPTION
- Fix dead Eclipse mirror (mirror.cc.vt.edu -> ftp.fau.de)
- Fix GitHub Desktop (shiftkey 404 -> mwt mirror)
- Fix Arduino version detection (broken HTML page -> GitHub API)
- Fix Google Cloud SDK repo (el7 -> el9)
- Fix FortiClient repo path (7.0 -> 7.4)
- Fix Mullvad VPN install (use official repo file)
- Fix Proton VPN copy-paste bug (had AnyDesk URL)
- Fix OneDrive docs link (INSTALL.md -> install.md)
- Fix Brave docs link
- Mark BlueJeans as deprecated (service discontinued)
- Add dnf5 compatibility for config-manager calls (sublimetext, dockerce, githubcli, spotify, microsoft-edge, mullvadvpn, nvidia-cuda el9/el10)
- Detection via dnf5 binary instead of VERSION_ID for portability